### PR TITLE
refactor: support custom Amiga GCC path and modernize function declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,23 +38,23 @@ build/obj/%.o: %.c $(HEADERS) $(COMMON_DEPS)
 
 build/obj/amiga/%.o: %.c $(COMMON_DEPS)
 	@mkdir -p build/obj/amiga
-	$(AMIGA_GCC) $(AMIGA_GCC_CFLAGS) $*.c -c -o build/obj/amiga/$*.o
+	$(AMIGA_BIN) $(AMIGA_GCC_CFLAGS) $*.c -c -o build/obj/amiga/$*.o
 
 build/amiga/squirtd: squirtd.c $(COMMON_DEPS)
 	@mkdir -p build/amiga
-	$(AMIGA_GCC) squirtd.c -s $(AMIGA_SQUIRTD_CFLAGS) $(SQUIRTD_AMIGA_GCC_OBJS) -o build/amiga/squirtd -lamiga
+	$(AMIGA_BIN) squirtd.c -s $(AMIGA_SQUIRTD_CFLAGS) $(SQUIRTD_AMIGA_GCC_OBJS) -o build/amiga/squirtd -lamiga
 
 build/amiga/ssum: build/obj/amiga/crc32.o build/obj/amiga/sum.o crc32.h $(COMMON_DEPS)
 	@mkdir -p build/amiga
-	$(AMIGA_GCC) $(AMIGA_GCC_CFLAGS) -s build/obj/amiga/crc32.o build/obj/amiga/sum.o -o build/amiga/ssum -lamiga
+	$(AMIGA_BIN) $(AMIGA_GCC_CFLAGS) -s build/obj/amiga/crc32.o build/obj/amiga/sum.o -o build/amiga/ssum -lamiga
 
 build/amiga/skill: kill.c $(COMMON_DEPS)
 	@mkdir -p build/amiga
-	$(AMIGA_GCC) $(AMIGA_SQUIRTD_CFLAGS) -s kill.c -o build/amiga/skill -lamiga
+	$(AMIGA_BIN) $(AMIGA_SQUIRTD_CFLAGS) -s kill.c -o build/amiga/skill -lamiga
 
 build/amiga/sps: ps.c $(COMMON_DEPS)
 	@mkdir -p build/amiga
-	$(AMIGA_GCC) $(AMIGA_SQUIRTD_CFLAGS) -s ps.c -o build/amiga/sps -lamiga
+	$(AMIGA_BIN) $(AMIGA_SQUIRTD_CFLAGS) -s ps.c -o build/amiga/sps -lamiga
 
 install: all
 	cp $(HOST_CLIENT_APPS) /usr/local/bin/

--- a/argv.c
+++ b/argv.c
@@ -40,8 +40,7 @@ Boston, MA 02110-1301, USA.  */
  char *
  strdup(const char *s1);
 
-void argv_free (vector)
-     char **vector;
+void argv_free (char **vector)
 {
   register char **scan;
 

--- a/platforms.mk
+++ b/platforms.mk
@@ -52,8 +52,13 @@ LIBS=$(MINGW_LIBS)
 STATIC_ANALYZE=
 endif
 
+# Use environment variable for Amiga GCC path if set, otherwise use default
+ifndef AMIGA_GCC
 AMIGA_GCC_PREFIX=/usr/local/amiga/bebbo
-AMIGA_GCC=$(AMIGA_GCC_PREFIX)/bin/m68k-amigaos-gcc -I$(AMIGA_GCC_PREFIX)/m68k-amigaos/ndk-include/
+else
+AMIGA_GCC_PREFIX=$(AMIGA_GCC)
+endif
+AMIGA_BIN=$(AMIGA_GCC_PREFIX)/bin/m68k-amigaos-gcc -I$(AMIGA_GCC_PREFIX)/m68k-amigaos/ndk-include/
 
 AMIGA_GCC_CFLAGS=-DAMIGA -Os -msmall-code -fomit-frame-pointer -noixemul $(WARNINGS)
 AMIGA_SQUIRTD_CFLAGS=$(AMIGA_GCC_CFLAGS) -fwhole-program


### PR DESCRIPTION
Now AMIGA_GCC is found correctly if you have it in a different path by setting for example:
export AMIGA_GCC=/opt/amiga
export PATH=$PATH:$AMIGA_GCC/bin

however it still check also in bebbo...

Solved a compilation issue now declared old style by converting it i the new way.