### PR TITLE
resolve alpine9000/squirt#18 handle quoted paths and spaces in command arguments correctly, new cu…

### DIFF
--- a/cli.c
+++ b/cli.c
@@ -1,18 +1,21 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <string.h>
-#include <errno.h>
+#include <ctype.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <limits.h>
 #include <fcntl.h>
-#include <unistd.h>
-#include <dirent.h>
-#include <readline/readline.h>
-#include <readline/history.h>
+#include <time.h>
+#include <stdarg.h>
+#include <errno.h>
 
 #include "main.h"
 #include "common.h"
 #include "argv.h"
+#include "srl.h"
+#include "exec.h"
 
 typedef struct hostfile {
   char* localFilename;
@@ -24,10 +27,15 @@ typedef struct hostfile {
   uint32_t remoteProtection;
 } cli_hostfile_t;
 
+// Forward declarations
+static int cli_isLocalFileArgumentForExecution(const char* arg);
+static char* cli_expandLocalPath(const char* path);
+
 static char* cli_currentDir = 0;
 static dir_entry_list_t *cli_dirEntryList = 0;
 static char* cli_readLineBase = 0;
-
+static char* cli_reconstructedText = 0;
+static int cli_isLocalCompletion = 0;  // Flag for local filesystem completion
 
 void
 cli_cleanup(void)
@@ -263,6 +271,14 @@ static int
 cli_saveFileIfModified(cli_hostfile_t* file)
 {
   int success = 0;
+  
+  // Check if the local file still exists (might have been deleted by local command)
+  struct stat st;
+  if (stat(file->localFilename, &st) != 0) {
+    // File was deleted by local command, skip upload
+    return 1; // Consider this "successful" - the file was intentionally removed
+  }
+  
   if (cli_compareFile(file->localFilename, file->backupFilename) == 0) {
     success = squirt_file(file->localFilename, 0, file->remoteFilename, 1, 0) == 0;
     if (success) {
@@ -273,7 +289,6 @@ cli_saveFileIfModified(cli_hostfile_t* file)
   return success;
 }
 
-
 static int
 cli_hostCommand(int argc, char** argv)
 {
@@ -282,8 +297,31 @@ cli_hostCommand(int argc, char** argv)
 
   cli_hostfile_t* list = 0;
 
+
+
+  // Store original remote source path for protection bits (BEFORE argument processing)
+  char* originalSourcePath = NULL;
+  char* baseCommand = argv[0][0] == '!' ? &argv[0][1] : argv[0];
+  int isCopyCommand = (strcmp(baseCommand, "cp") == 0 || strcmp(baseCommand, "copy") == 0);
+  int destinationIndex = isCopyCommand && argc > 2 ? argc - 1 : -1;
+  
+  // For copy commands, store original source path before it gets modified
+  if (isCopyCommand && argc >= 3) {
+    int sourceIsLocal = cli_isLocalFileArgumentForExecution(argv[1]);
+    int sourceIsRemote = !sourceIsLocal && argv[1][0] != '-';
+    if (sourceIsRemote) {
+      originalSourcePath = strdup(argv[1]);
+    }
+  }
+  
   for (int i = 1; i < argc; i++) {
-    if (argv[i][0] != '~' && argv[i][0] != '!' && argv[i][0] != '-' && argv[i][0] != '|' && argv[i][0] != '>') {
+    int isLocal = cli_isLocalFileArgumentForExecution(argv[i]);
+    int isDestination = (i == destinationIndex);
+    
+    // Skip local files, destinations, command options, and shell operators
+    if (!isLocal && !isDestination &&
+        argv[i][0] != '-' && argv[i][0] != '|' && argv[i][0] != '>') {
+      // This is a remote source file - transfer it to local temp directory
       cli_hostfile_t* hostFile = cli_convertFileToHost(&list, argv[i]);
       if (hostFile) {
 	hostFile->argv = &argv[i];
@@ -291,19 +329,157 @@ cli_hostCommand(int argc, char** argv)
       } else {
 	goto error;
       }
+    } else {
+      // Skip destinations, local files, options, and operators
     }
   }
 
   char** newArgv = malloc(sizeof(char*)*(argc+1));
+  char** expandedPaths = malloc(sizeof(char*)*(argc+1));
+  int expandedCount = 0;
 
   for (int i = 0; i < argc; i++) {
-    char* ptr = argv[i][0] == '!' ? &argv[i][1] : argv[i];
-    newArgv[i] = ptr;
+    if (i == 0) {
+      // Strip the '!' prefix from the command
+      newArgv[i] = argv[i][0] == '!' ? &argv[i][1] : argv[i];
+    } else if (cli_isLocalFileArgumentForExecution(argv[i])) {
+      char* expandedPath = cli_expandLocalPath(argv[i]);
+      if (expandedPath) {
+        newArgv[i] = expandedPath;
+        expandedPaths[expandedCount++] = expandedPath; // Track for cleanup
+      } else {
+        newArgv[i] = argv[i];
+      }
+    } else {
+      newArgv[i] = argv[i];
+    }
   }
   newArgv[argc] = 0;
 
-  success = util_system(newArgv);
+  // Check for hybrid operations (local-to-remote, remote-to-remote)
+  int sourceIsLocal = 0, sourceIsRemote = 0, destIsRemote = 0;
+  char* sourcePath = NULL;
+  char* destPath = NULL;
+  if (isCopyCommand && argc == 3) {
+    sourceIsLocal = cli_isLocalFileArgumentForExecution(argv[1]);
+    sourceIsRemote = !sourceIsLocal && argv[1][0] != '-';
+    destIsRemote = !cli_isLocalFileArgumentForExecution(argv[2]) && argv[2][0] != '-';
+    
+    if ((sourceIsLocal && destIsRemote) || (sourceIsRemote && destIsRemote)) {
+      
+      // Get the source file path (either expanded local or downloaded temp file)
+      sourcePath = newArgv[1];
+      destPath = argv[2];
+      
+      // Strip quotes from remote path if present
+      char unquotedRemotePath[PATH_MAX];
+      int remotePathLen = strlen(destPath);
+      if ((destPath[0] == '"' && destPath[remotePathLen-1] == '"' && remotePathLen > 1) ||
+          (destPath[0] == '\'' && destPath[remotePathLen-1] == '\'' && remotePathLen > 1)) {
+        // Remove quotes
+        strncpy(unquotedRemotePath, destPath + 1, remotePathLen - 2);
+        unquotedRemotePath[remotePathLen - 2] = '\0';
+      } else {
+        strcpy(unquotedRemotePath, destPath);
+      }
+      // Extract filename for destination path construction
+      char* filename;
+      if (sourceIsLocal) {
+        // For local files, extract filename from the source path
+        filename = strrchr(sourcePath, '/');
+        if (filename) {
+          filename++; // Skip the '/'
+        } else {
+          filename = sourcePath; // No path separator, use whole string
+        }
+      } else {
+        // For remote files, extract filename from original remote path (argv[1])
+        char* originalRemotePath = argv[1];
+        filename = strrchr(originalRemotePath, ':');
+        if (filename) {
+          filename++; // Skip the ':'
+        } else {
+          filename = originalRemotePath; // No colon, use whole string
+        }
+      }
+      
+      // Construct full destination path
+      char fullDestPath[PATH_MAX];
+      if (unquotedRemotePath[strlen(unquotedRemotePath)-1] == ':') {
+        // Directory destination (ends with :), append filename
+        snprintf(fullDestPath, sizeof(fullDestPath), "%s%s", unquotedRemotePath, filename);
+      } else {
+        // File destination, use as-is
+        strncpy(fullDestPath, unquotedRemotePath, sizeof(fullDestPath)-1);
+        fullDestPath[sizeof(fullDestPath)-1] = '\0';
+      }
+      
+      // Use squirt to transfer the file
+      success = squirt_file(sourcePath, 0, fullDestPath, 1, 0) == 0;
+      
+      if (success) {
+        // For remote-to-remote operations, preserve protection bits from source
+        if (sourceIsRemote && destIsRemote) {
+          
+          // Query source file protection bits by listing its directory
+          char* sourceFilePath = originalSourcePath ? originalSourcePath : argv[1];
+          char dirPath[PATH_MAX];
+          char* fileName;
+          
+          // Extract directory and filename from source path
+          char* lastColon = strrchr(sourceFilePath, ':');
+          if (lastColon) {
+            // Amiga-style path (e.g., "S:Startup-sequence")
+            size_t dirLen = lastColon - sourceFilePath + 1; // Include the colon
+            strncpy(dirPath, sourceFilePath, dirLen);
+            dirPath[dirLen] = '\0';
+            fileName = lastColon + 1;
+          } else {
+            // No colon found, assume current directory
+            strcpy(dirPath, "");
+            fileName = sourceFilePath;
+          }
+          
+          dir_entry_list_t* dirInfo = dir_read(dirPath);
+          
+          if (dirInfo) {
+            // Search for the specific file in the directory listing
+            dir_entry_t* entry = dirInfo->head;
+            int found = 0;
+            
+            while (entry && !found) {
+              if (strcmp(entry->name, fileName) == 0) {
+                uint32_t sourceProtection = entry->prot;
+                
+                // Apply protection bits to destination file
+                protect_file(fullDestPath, sourceProtection, 0);
+                found = 1;
+              }
+              entry = entry->next;
+            }
+            
+            dir_freeEntryList(dirInfo);
+          }
+        }
+      }
+      
+      // Clean up allocated memory
+      if (originalSourcePath) {
+        free(originalSourcePath);
+      }
+    } else {
+      success = util_system(newArgv);
+    }
+  } else {
+    success = util_system(newArgv);
+  }
   free(newArgv);
+  
+  // Clean up expanded paths
+  for (int i = 0; i < expandedCount; i++) {
+    free(expandedPaths[i]);
+  }
+  free(expandedPaths);
 
  error:
   {
@@ -360,7 +536,7 @@ cli_runCommand(char* line)
     return code;
   } else if (strncasecmp(line, "cd ", 3) == 0 || 
              (strchr(line, ':') != NULL && strchr(line, ' ') == NULL) || 
-             line[end] == '/' || 
+             (line[end] == '/' && strchr(line, ' ') == NULL) || 
              (strchr(line, '/') != NULL && strchr(line, ' ') == NULL) ||
              (line[0] == '"' && strchr(line + 1, '"') != NULL)) {  // Added check for quoted paths
     char* cmd = strdup(line);
@@ -413,6 +589,43 @@ cli_runCommand(char* line)
   } else if (argv[0][0] == '!') {
     code = cli_hostCommand(argc, argv);
   } else {
+    // Authentic Amiga behavior: for single words, try directory navigation first
+    // if it's not a known command
+    if (argc == 1 && strchr(argv[0], ' ') == NULL) {
+      // List of common Amiga commands that should NOT be treated as directories
+      const char* known_commands[] = {
+        "dir", "list", "copy", "delete", "rename", "makedir", "cd", "type",
+        "echo", "cls", "clear", "version", "date", "time", "info", "which",
+        "assign", "mount", "format", "protect", "comment", "relabel",
+        "diskchange", "install", "run", "execute", "newshell", "endcli",
+        "quit", "exit", "help", "?", "status", "stack", "path", "resident",
+        "alias", "unalias", "setenv", "getenv", "unsetenv", "eval",
+        NULL
+      };
+      
+      int is_known_command = 0;
+      for (int i = 0; known_commands[i] != NULL; i++) {
+        if (strcasecmp(argv[0], known_commands[i]) == 0) {
+          is_known_command = 1;
+          break;
+        }
+      }
+      
+      if (!is_known_command) {
+        // Try as directory navigation first
+        if (exec_cmd(2, (char*[]){"cd", argv[0]}) == 0) {
+          const char* new_path = cwd_read();
+          if (new_path) {
+            cli_changeDir(new_path);
+            code = 1; // Success
+            return code; // Don't try as command
+          }
+        }
+        // If directory change failed, fall through to try as command
+      }
+    }
+    
+    // Execute as regular command
     code = exec_cmd(argc, argv);
   }
 
@@ -429,9 +642,559 @@ cli_onExit(void)
 }
 
 
+static char**
+cli_queryAmigaAssigns(int* count)
+{
+  // Query Amiga system for actual assigns, devices, and volumes
+  // This provides truly authentic completion based on real system state
+  
+  *count = 0;
+  char** assigns = NULL;
+  int capacity = 50; // Initial capacity
+  
+  assigns = malloc(capacity * sizeof(char*));
+  if (!assigns) return NULL;
+  
+  // Query actual Amiga system for real assigns using exec_captureCmd
+  uint32_t error_code;
+  char* assign_output = exec_captureCmd(&error_code, 1, (char*[]){"assign"});
+  
+
+  
+  if (assign_output && error_code == 0) {
+    // Parse assign command output: "AssignName: path"
+    char* line = strtok(assign_output, "\n");
+    while (line) {
+      // Skip header lines like "Volumes:", "Directories:", "Devices:"
+      if (strstr(line, "Volumes:") || strstr(line, "Directories:") || strstr(line, "Devices:") || strstr(line, "Denied volume requests:") || strstr(line, "disks:")) {
+        line = strtok(NULL, "\n");
+        continue;
+      }
+      
+      // Find first non-space character (start of assign name)
+      char* start = line;
+      while (*start == ' ') start++;
+      
+      // Find first space after assign name
+      char* space = strchr(start, ' ');
+      if (space && space > start) {
+        // Extract just the assign name and add colon
+        int name_len = space - start;
+        char* assign_name = malloc(name_len + 2); // +2 for colon and null
+        if (assign_name) {
+          strncpy(assign_name, start, name_len);
+          assign_name[name_len] = ':';
+          assign_name[name_len + 1] = '\0';
+          
+          // Add to list (resize if needed)
+          if (*count >= capacity - 1) {
+            capacity *= 2;
+            assigns = realloc(assigns, capacity * sizeof(char*));
+            if (!assigns) break;
+          }
+          
+          // Check for duplicates (case-insensitive)
+          int is_duplicate = 0;
+          for (int j = 0; j < *count; j++) {
+            if (strcasecmp(assigns[j], assign_name) == 0) {
+              is_duplicate = 1;
+              free(assign_name); // Free the duplicate
+              break;
+            }
+          }
+          
+          if (!is_duplicate) {
+            assigns[*count] = assign_name;
+            (*count)++;
+          }
+        }
+      }
+      line = strtok(NULL, "\n");
+    }
+    free(assign_output);
+  }
+  
+  // Query actual Amiga system for volumes/devices using info command
+  char* info_output = exec_captureCmd(&error_code, 1, (char*[]){"info"});
+  
+
+  
+  if (info_output && error_code == 0) {
+    // Parse info command output to find volume names in "Volumes available:" section
+    char* line = strtok(info_output, "\n");
+    int in_volumes_section = 0;
+    
+    while (line) {
+      // Check if we're entering the volumes section
+      if (strstr(line, "Volumes available:")) {
+        in_volumes_section = 1;
+        line = strtok(NULL, "\n");
+        continue;
+      }
+      
+      // If we're in the volumes section, parse volume names
+      if (in_volumes_section) {
+        // Skip empty lines
+        char* trimmed = line;
+        while (*trimmed == ' ' || *trimmed == '\t') trimmed++;
+        if (strlen(trimmed) == 0) {
+          line = strtok(NULL, "\n");
+          continue;
+        }
+        
+        // Look for volume names followed by [Mounted]
+        char* mounted_pos = strstr(trimmed, " [Mounted]");
+        if (mounted_pos) {
+          // Extract volume name (everything before " [Mounted]")
+          int volume_name_len = mounted_pos - trimmed;
+          char* volume_name = malloc(volume_name_len + 2); // +2 for colon and null
+          if (volume_name) {
+            strncpy(volume_name, trimmed, volume_name_len);
+            volume_name[volume_name_len] = ':';
+            volume_name[volume_name_len + 1] = '\0';
+            
+            // Add volume to list (resize if needed)
+            if (*count >= capacity - 1) {
+              capacity *= 2;
+              assigns = realloc(assigns, capacity * sizeof(char*));
+              if (!assigns) {
+                free(volume_name);
+                break;
+              }
+            }
+            
+            // Check for duplicates (case-insensitive)
+            int is_duplicate = 0;
+            for (int j = 0; j < *count; j++) {
+              if (strcasecmp(assigns[j], volume_name) == 0) {
+                is_duplicate = 1;
+                free(volume_name); // Free the duplicate
+                break;
+              }
+            }
+            
+            if (!is_duplicate) {
+              assigns[*count] = volume_name;
+              (*count)++;
+            }
+          }
+        }
+      }
+      
+      line = strtok(NULL, "\n");
+    }
+    free(info_output);
+  }
+  
+  // If no assigns/volumes found, add basic fallback
+  if (*count == 0) {
+    static int warning_shown = 0;
+    if (!warning_shown) {
+      printf("Warning: Unable to query Amiga system for assigns/volumes, using fallback list\n");
+      warning_shown = 1;
+    }
+    const char* fallback_assigns[] = {
+      "SYS:", "RAM:", "DF0:", NULL
+    };
+    
+    for (int i = 0; fallback_assigns[i] != NULL; i++) {
+      if (*count >= capacity - 1) {
+        capacity *= 2;
+        assigns = realloc(assigns, capacity * sizeof(char*));
+        if (!assigns) break;
+      }
+      
+      assigns[*count] = strdup(fallback_assigns[i]);
+      if (assigns[*count]) (*count)++;
+    }
+  }
+  
+  // Null-terminate the array
+  if (*count < capacity) {
+    assigns[*count] = NULL;
+  }
+  
+
+  
+  return assigns;
+}
+
+
+static char*
+cli_getAmigaAssignSuggestion(int* list_index, const char* match_text, int match_len)
+{
+  // Dynamic Amiga assign/device/volume detection by querying actual system
+  // This provides authentic completion suggestions based on real Amiga state
+  
+  // Dynamic assign/device/volume detection by querying actual Amiga system
+  static char** cached_assigns = NULL;
+  static int cached_count = 0;
+  static time_t last_cache_time = 0;
+  
+  // Refresh cache every 30 seconds or on first call
+  time_t current_time = time(NULL);
+  if (!cached_assigns || (current_time - last_cache_time) > 30) {
+    // Free previous cache
+    if (cached_assigns) {
+      for (int i = 0; i < cached_count; i++) {
+        free(cached_assigns[i]);
+      }
+      free(cached_assigns);
+    }
+    
+    // Query Amiga system for actual assigns and volumes
+    cached_assigns = cli_queryAmigaAssigns(&cached_count);
+    last_cache_time = current_time;
+  }
+  
+  // Use cached results (fallback to basic list if query fails)
+  const char** assigns_to_use;
+  int assign_count;
+  
+  if (cached_assigns && cached_count > 0) {
+    assigns_to_use = (const char**)cached_assigns;
+    assign_count = cached_count;
+
+  } else {
+    // Fallback to basic common assigns if dynamic query fails
+    static const char* fallback_assigns[] = {
+      "WORK:", "WORKBENCH:", "SYS:", "SYSTEM:", "C:", "S:", "L:", "LIBS:",
+      "DEVS:", "FONTS:", "PREFS:", "T:", "RAM:", "DF0:", "DF1:", "DH0:", "DH1:",
+      NULL
+    };
+    assigns_to_use = fallback_assigns;
+    assign_count = 17; // Count of fallback assigns
+  }
+  
+  // Count matching assigns first to know total matches
+  int total_assign_matches = 0;
+  for (int i = 0; i < assign_count && assigns_to_use[i]; i++) {
+    if (strncasecmp(assigns_to_use[i], match_text, match_len) == 0) {
+      total_assign_matches++;
+    }
+  }
+  
+  // Simple assign completion - the caller manages the list_index properly
+  // We just need to return the assign at the current relative position
+  
+  // Count how many file/directory matches we've already processed
+  // by checking how many matches exist in the file list
+  int file_matches = 0;
+  if (cli_dirEntryList) {
+    dir_entry_t* ptr = cli_dirEntryList->head;
+    while (ptr) {
+      // Skip .info files
+      int name_len = strlen(ptr->name);
+      if (name_len >= 5) {
+        const char* extension = &ptr->name[name_len - 5];
+        if (strcasecmp(extension, ".info") == 0) {
+          ptr = ptr->next;
+          continue;
+        }
+      }
+      
+      char buffer[PATH_MAX];
+      snprintf(buffer, sizeof(buffer), "%s%s", cli_readLineBase, ptr->name);
+      if (strncasecmp(buffer, match_text, match_len) == 0) {
+        file_matches++;
+      }
+      ptr = ptr->next;
+    }
+  }
+  
+  // The assign index should be relative to the number of file matches
+  int assign_relative_index = *list_index - file_matches;
+  
+  // Return the assign at the relative index
+  int assign_index = 0;
+  for (int i = 0; i < assign_count && assigns_to_use[i]; i++) {
+    if (strncasecmp(assigns_to_use[i], match_text, match_len) == 0) {
+      if (assign_index == assign_relative_index) {
+        (*list_index)++;
+        return strdup(assigns_to_use[i]);
+      }
+      assign_index++;
+    }
+  }
+  
+  return NULL;
+}
+
+
+// Local filesystem completion functions
+static int
+cli_isLocalCommand(const char* command_line)
+{
+  // Check if command starts with '!' (local command)
+  if (command_line && command_line[0] == '!') {
+    return 1;
+  }
+  return 0;
+}
+
+static int
+cli_isLocalFileArgument(const char* arg)
+{
+  // Check if argument starts with '!' or '~' (local file)
+  if (arg && (arg[0] == '!' || arg[0] == '~')) {
+    return 1;
+  }
+  return 0;
+}
+
+static int
+cli_isLocalFileArgumentForExecution(const char* arg)
+{
+  // Check if argument is a local file, handling quoted paths
+  if (!arg) return 0;
+  
+  // Direct check for ! or ~ prefix
+  if (arg[0] == '!' || arg[0] == '~') {
+    return 1;
+  }
+  
+  // Check for quoted local files: "~/path" or "!/path"
+  if (arg[0] == '"' && strlen(arg) > 2) {
+    if (arg[1] == '~' || arg[1] == '!') {
+      return 1;
+    }
+  }
+  
+  // Check for single-quoted local files: '~/path' or '!/path'
+  if (arg[0] == '\'' && strlen(arg) > 2) {
+    if (arg[1] == '~' || arg[1] == '!') {
+      return 1;
+    }
+  }
+  
+  return 0;
+}
+
+static char*
+cli_expandLocalPath(const char* path)
+{
+  if (!path) return NULL;
+  
+  char* expanded = malloc(PATH_MAX);
+  if (!expanded) return NULL;
+  
+  // Handle quoted paths by extracting the inner path
+  const char* inner_path = path;
+  int path_len = strlen(path);
+  
+  // Strip outer quotes if present
+  if ((path[0] == '"' && path[path_len-1] == '"' && path_len > 1) ||
+      (path[0] == '\'' && path[path_len-1] == '\'' && path_len > 1)) {
+    // Create a temporary unquoted version
+    char* temp_path = malloc(path_len);
+    if (!temp_path) {
+      free(expanded);
+      return NULL;
+    }
+    strncpy(temp_path, path + 1, path_len - 2);
+    temp_path[path_len - 2] = '\0';
+    inner_path = temp_path;
+  }
+  
+  if (inner_path[0] == '~') {
+    // Expand ~ to home directory
+    const char* home = getenv("HOME");
+    if (home) {
+      snprintf(expanded, PATH_MAX, "%s%s", home, inner_path + 1);
+    } else {
+      strcpy(expanded, inner_path);
+    }
+  } else if (inner_path[0] == '!') {
+    // Remove ! prefix for local files
+    strcpy(expanded, inner_path + 1);
+  } else {
+    strcpy(expanded, inner_path);
+  }
+  
+  // Clean up temporary path if we created one
+  if (inner_path != path) {
+    free((char*)inner_path);
+  }
+  
+  return expanded;
+}
+
+static char*
+cli_getLocalFileSuggestion(int* list_index, const char* text, int len)
+{
+  (void)len; // Unused parameter
+  static DIR* dir_handle = NULL;
+  static char* dir_path = NULL;
+  static int current_index = 0;
+  
+  // Reset on new completion
+  if (*list_index == 0) {
+    if (dir_handle) {
+      closedir(dir_handle);
+      dir_handle = NULL;
+    }
+    if (dir_path) {
+      free(dir_path);
+      dir_path = NULL;
+    }
+    current_index = 0;
+    
+    // Extract directory path from text
+    char* expanded_text = cli_expandLocalPath(text);
+    if (!expanded_text) return NULL;
+    
+    char* last_slash = strrchr(expanded_text, '/');
+    if (last_slash) {
+      *last_slash = '\0';
+      dir_path = strdup(expanded_text);
+    } else {
+      dir_path = strdup(".");
+    }
+    
+    dir_handle = opendir(dir_path);
+    free(expanded_text);
+    
+    if (!dir_handle) {
+      if (dir_path) {
+        free(dir_path);
+        dir_path = NULL;
+      }
+      return NULL;
+    }
+  }
+  
+  if (!dir_handle) return NULL;
+  
+  // Get filename portion for matching
+  char* expanded_text = cli_expandLocalPath(text);
+  if (!expanded_text) return NULL;
+  
+  char* filename_part = strrchr(expanded_text, '/');
+  if (filename_part) {
+    filename_part++; // Skip the '/'
+  } else {
+    filename_part = expanded_text;
+  }
+  int filename_len = strlen(filename_part);
+  
+  struct dirent* entry;
+  while ((entry = readdir(dir_handle)) != NULL) {
+    // Skip . and ..
+    if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+      continue;
+    }
+    
+    // Check if entry matches prefix (case-insensitive)
+    if (strncasecmp(entry->d_name, filename_part, filename_len) == 0) {
+      if (current_index == *list_index) {
+        (*list_index)++;
+        current_index++;
+        
+        // Build full path
+        char* result = malloc(PATH_MAX);
+        
+        // Preserve the original prefix (! or ~) in completion results
+        const char* prefix = "";
+        if (text[0] == '!') {
+          prefix = "!";
+        } else if (text[0] == '~') {
+          prefix = "~";
+        }
+        
+        if (strcmp(dir_path, ".") == 0) {
+          snprintf(result, PATH_MAX, "%s%s", prefix, entry->d_name);
+        } else {
+          // For ~ paths, we need to construct the path relative to the original ~ prefix
+          if (text[0] == '~') {
+            // Extract the path after ~ from the original text
+            const char* home = getenv("HOME");
+            if (home && strncmp(dir_path, home, strlen(home)) == 0) {
+              // dir_path starts with home directory, so we can reconstruct with ~
+              const char* relative_path = dir_path + strlen(home);
+              if (strlen(relative_path) > 0) {
+                snprintf(result, PATH_MAX, "~%s/%s", relative_path, entry->d_name);
+              } else {
+                snprintf(result, PATH_MAX, "~/%s", entry->d_name);
+              }
+            } else {
+              // Fallback to full path with ~ prefix
+              snprintf(result, PATH_MAX, "~/%s", entry->d_name);
+            }
+          } else {
+            snprintf(result, PATH_MAX, "%s%s/%s", prefix, dir_path, entry->d_name);
+          }
+        }
+        
+        // Check if it's a directory and add trailing slash
+        char full_path[PATH_MAX];
+        snprintf(full_path, PATH_MAX, "%s/%s", dir_path, entry->d_name);
+        struct stat st;
+        int is_directory = (stat(full_path, &st) == 0 && S_ISDIR(st.st_mode));
+        
+        // Add quoting for paths with spaces (like Amiga completion does)
+        extern int _srl_inside_quotes_flag;
+        int already_quoted = _srl_inside_quotes_flag;
+        
+        if (strchr(result, ' ') != NULL) {
+          // Path contains spaces - needs quoting
+          char* quoted_result = malloc(strlen(result) + 10);
+          if (is_directory) {
+            if (already_quoted) {
+              sprintf(quoted_result, "%s/\"", result);
+            } else {
+              sprintf(quoted_result, "\"%s/\"", result);
+            }
+          } else {
+            if (already_quoted) {
+              sprintf(quoted_result, "%s\"", result);
+            } else {
+              sprintf(quoted_result, "\"%s\"", result);
+            }
+          }
+          free(result);
+          result = quoted_result;
+        } else {
+          // No spaces - just add trailing slash for directories
+          if (is_directory) {
+            strcat(result, "/");
+          }
+        }
+        
+        free(expanded_text);
+        return result;
+      }
+      current_index++;
+    }
+  }
+  
+  // Cleanup when done
+  if (dir_handle) {
+    closedir(dir_handle);
+    dir_handle = NULL;
+  }
+  if (dir_path) {
+    free(dir_path);
+    dir_path = NULL;
+  }
+  current_index = 0;
+  
+  free(expanded_text);
+  return NULL;
+}
+
+
 static char*
 cli_completeGenerator(int* list_index, const char* text, int len)
 {
+  // Check if we should use local filesystem completion
+  if (cli_isLocalCompletion) {
+    return cli_getLocalFileSuggestion(list_index, text, len);
+  }
+  
+  // Use reconstructed text for quoted paths, otherwise use original text
+  const char* match_text = cli_reconstructedText ? cli_reconstructedText : text;
+  int match_len = cli_reconstructedText ? (int)strlen(cli_reconstructedText) : len;
+  
   dir_entry_t* ptr;
   if (cli_dirEntryList) {
     ptr = cli_dirEntryList->head;
@@ -439,21 +1202,71 @@ cli_completeGenerator(int* list_index, const char* text, int len)
     ptr = 0;
   }
 
-  for (int i = 0; i < *list_index && ptr; i++) {
-    ptr = ptr->next;
-  }
-
+  // Process all matches (directories and files) for ambiguous completion
+  int current_index = 0;
   while (ptr) {
-    (*list_index)++;
     dir_entry_t* entry = ptr;
     ptr = ptr->next;
+
+    // Skip .info files (authentic Amiga shell behavior)
+    int name_len = strlen(entry->name);
+    if (name_len >= 5) {
+      const char* extension = &entry->name[name_len - 5];
+      if (strcasecmp(extension, ".info") == 0) {
+        continue; // Skip .info files
+      }
+    }
 
     char buffer[PATH_MAX];
     snprintf(buffer, sizeof(buffer), "%s%s", cli_readLineBase, entry->name);
 
-    if (strncmp(buffer, text, len) == 0) {
-      rl_completion_append_character = entry->type > 0 ? '/' : ' ';
-      return strdup(buffer);
+    // Check both directories and files in the same loop
+    if (strncasecmp(buffer, match_text, match_len) == 0) {
+      if (current_index == *list_index) {
+        (*list_index)++;
+        
+        extern int _srl_inside_quotes_flag;
+        int already_quoted = _srl_inside_quotes_flag;
+        
+        if (entry->type > 0) {
+          // Directory match
+          char* result = malloc(strlen(buffer) + 10);
+          if (strchr(buffer, ' ') != NULL) {
+            if (already_quoted) {
+              sprintf(result, "%s/\"", buffer);
+            } else {
+              sprintf(result, "\"%s/\"", buffer);
+            }
+          } else {
+            strcpy(result, buffer);
+            strcat(result, "/");
+          }
+          return result;
+        } else {
+          // File match
+          if (strchr(buffer, ' ') != NULL) {
+            char* result = malloc(strlen(buffer) + 3);
+            if (already_quoted) {
+              sprintf(result, "%s\"", buffer);
+            } else {
+              sprintf(result, "\"%s\"", buffer);
+            }
+            return result;
+          } else {
+            return strdup(buffer);
+          }
+        }
+      }
+      current_index++;
+    }
+  }
+
+  // After processing all file/directory matches, also check Amiga assigns/devices/volumes
+  // This matches authentic Amiga shell behavior by including assigns alongside files
+  if (match_len > 0) {
+    char* assign_result = cli_getAmigaAssignSuggestion(list_index, match_text, match_len);
+    if (assign_result) {
+      return assign_result;
     }
   }
 
@@ -462,24 +1275,59 @@ cli_completeGenerator(int* list_index, const char* text, int len)
 
 
 static void
-cli_completeHook(const char* text)
+cli_completeHook(const char* text, const char* full_command_line)
 {
+  // Reset local completion flag
+  cli_isLocalCompletion = 0;
+  
+  // ~ paths are ALWAYS local (Amiga doesn't have ~ expansion)
+  if (text && text[0] == '~') {
+    cli_isLocalCompletion = 1;
+  }
+  // ! paths are local only in local commands
+  else if (full_command_line && cli_isLocalCommand(full_command_line)) {
+    // Check if the current argument being completed is a local file
+    if (cli_isLocalFileArgument(text)) {
+      cli_isLocalCompletion = 1;
+    }
+  }
+  
   if (cli_readLineBase) {
     free(cli_readLineBase);
   }
-
-  cli_readLineBase = strdup(text);
-
-  int ei = strlen(cli_readLineBase);
-  while (ei >= 0 && cli_readLineBase[ei] != '/' && cli_readLineBase[ei] != ':') {
-    cli_readLineBase[ei] = 0;
-    ei--;
-  }
-  if (cli_dirEntryList) {
-    dir_freeEntryList(cli_dirEntryList);
+  if (cli_reconstructedText) {
+    free(cli_reconstructedText);
+    cli_reconstructedText = 0;
   }
 
-  cli_dirEntryList = dir_read(cli_readLineBase);
+  // Custom input wrapper: Simple text processing without readline dependencies
+  char* full_path = strdup(text);
+  // Note: cli_reconstructedText is now set only when inside quotes (from input wrapper)
+  
+  cli_readLineBase = strdup(full_path);
+
+  // Only process Amiga filesystem if not doing local completion
+  if (!cli_isLocalCompletion) {
+    int ei = strlen(cli_readLineBase);
+    while (ei >= 0 && cli_readLineBase[ei] != '/' && cli_readLineBase[ei] != ':') {
+      cli_readLineBase[ei] = 0;
+      ei--;
+    }
+    
+    if (cli_dirEntryList) {
+      dir_freeEntryList(cli_dirEntryList);
+    }
+
+    cli_dirEntryList = dir_read(cli_readLineBase);
+  } else {
+    // For local completion, we don't need Amiga directory listing
+    if (cli_dirEntryList) {
+      dir_freeEntryList(cli_dirEntryList);
+      cli_dirEntryList = NULL;
+    }
+  }
+  
+  free(full_path);
 }
 
 

--- a/mingw.mk
+++ b/mingw.mk
@@ -3,7 +3,7 @@ MINGW_GCC_CFLAGS=-O2 -s $(WARNINGS) -I/$(MINGW_GCC_PREFIX)/include
 MINGW_APPS=$(addsuffix .exe, $(addprefix build/mingw/, $(CLIENT_APPS)))
 SQUIRT_MINGW_OBJS=$(addprefix build/obj/mingw/, $(SQUIRT_SRCS:.c=.o))
 
-mingw: $(MINGW_APPS) build/mingw/libreadline8.dll build/mingw/libiconv-2.dll
+mingw: $(MINGW_APPS)
 
 build/mingw/%.dll: support/%.dll
 	@mkdir -p build/mingw

--- a/platforms.mk
+++ b/platforms.mk
@@ -17,7 +17,7 @@ ifneq (,$(findstring MINGW64,$(UNAME_S)))
 PLATFORM=mingw64
 endif
 
-MINGW_LIBS=-lws2_32 -liconv
+MINGW_LIBS=-lws2_32 -liconv -static
 
 ifeq ($(PLATFORM),osx)
 # OSX

--- a/platforms.mk
+++ b/platforms.mk
@@ -17,23 +17,23 @@ ifneq (,$(findstring MINGW64,$(UNAME_S)))
 PLATFORM=mingw64
 endif
 
-MINGW_LIBS=-lws2_32 -liconv -lreadline
+MINGW_LIBS=-lws2_32 -liconv
 
 ifeq ($(PLATFORM),osx)
 # OSX
-CC=gcc -I/opt/homebrew/opt/readline/include/ -I/opt/homebrew/opt/libiconv/include
+CC=gcc -I/opt/homebrew/opt/libiconv/include
 STATIC_ANALYZE=-fsanitize=address -fsanitize=undefined
 ifeq ($(RELEASE),true)
-LIBS=-L/opt/homebrew/opt/readline/lib/ -L/opt/homebrew/opt/libiconv/lib -liconv -lcharset -ltermcap -lreadline
+LIBS=-L/opt/homebrew/opt/libiconv/lib -liconv -lcharset -ltermcap
 else
-LIBS=-liconv -ltermcap -lreadline
+LIBS=-liconv -ltermcap
 endif
 MINGW_GCC_PREFIX=/usr/local/mingw
 MINGW_GCC=$(MINGW_GCC_PREFIX)/bin/x86_64-w64-mingw32-gcc
 else ifeq ($(PLATFORM),raspberry_pi)
 # Raspberry Pi
 CC=gcc
-LIBS=-lreadline
+LIBS=
 else ifeq ($(PLATFORM),linux)
 # Linux
 ifeq ($(RELEASE),true)
@@ -41,7 +41,7 @@ else
 CC=gcc-10
 endif
 STATIC_ANALYZE=-fanalyzer -fsanitize=address -fsanitize=undefined
-LIBS=-lreadline
+LIBS=
 MINGW_GCC_PREFIX=/usr/x86_64-w64-mingw32
 MINGW_GCC=x86_64-w64-mingw32-gcc
 else ifeq ($(PLATFORM),mingw64)

--- a/squirt.c
+++ b/squirt.c
@@ -7,6 +7,7 @@
 #include <libgen.h>
 #include <getopt.h>
 #include <limits.h>
+#include <errno.h>
 #include <sys/time.h>
 #include <sys/stat.h>
 
@@ -42,7 +43,8 @@ squirt_file(const char* filename, const char* progressHeader, const char* destFi
   struct timeval start, end;
 
   if (stat(filename, &st) == -1) {
-    fatalError("filed to stat %s", filename);
+    fprintf(stderr, "Error: Cannot access file '%s' - %s\n", filename, strerror(errno));
+    return -1; // Return error code instead of terminating
   }
 
   fileLength = st.st_size;

--- a/srl.h
+++ b/srl.h
@@ -1,7 +1,9 @@
 #pragma once
 
 void
-srl_init(const char*(*_srl_prompt)(void),void (*complete_hook)(const char* text), char* (*generator)(int* list_index, const char* text, int len));
+srl_init(const char*(*_srl_prompt)(void),void (*complete_hook)(const char* text, const char* full_command_line), char* (*generator)(int* list_index, const char* text, int len));
+
+char* srl_escape_spaces(const char* str);
 
 void
 srl_write_history(void);


### PR DESCRIPTION
…stom-wrapper readline replacement, AmigaOS 3.2 cli behaviour, dynamic list of assigns, volumes, etc.

Local PC file suggesstion from home dir and autocomplete:
1.Work:> !cp ~/ +tab
~/.config/ ~/.bash_logout ~/.bash_profile ~/.bashrc ~/.screenrc ~/.zshrc ~/Desktop/ ~/Downloads/

Local PC file suggesstion from current dir and autocomplete:
1.Work:> ! +tab
!.git/ !.gitignore !LICENSE !Makefile !README.md !argv.c !argv.h !backup.h !cli.h !common.h !crc32.c

Remote Amiga:
1.Work:> e +tab
Empty File Empty File2 EMU68BOOT: ENV: ENVARC:

1.Work:> emp +tab
Empty File Empty File2 EMU68BOOT:
1.Work:> "Empty File

As you can see it correctly handles files with spaces both on local and remote machines, and what was a tricky one it gets all the assigns,volumes, etc. from the real amiga refreshing it every 30 sec(waning if it does not only on first attempt) and make available for fast suggestion and autocomplete.



